### PR TITLE
Fix broken links inside markdown blockquote

### DIFF
--- a/src/no-dead-relative-link.js
+++ b/src/no-dead-relative-link.js
@@ -15,7 +15,7 @@ const externalLinkRegex = new RegExp(/^[a-z][a-z0-9+.-]*:/, 'i');
 
 export default function(context, options) {
     return wrapReportHandler(context, {
-        ignoreNodeTypes: [Syntax.BlockQuote, Syntax.code]
+        ignoreNodeTypes: [Syntax.code]
     }, () => handler(context, options));
 }
 

--- a/test/fixtures/testFiles/invalidLinkTest.md
+++ b/test/fixtures/testFiles/invalidLinkTest.md
@@ -5,3 +5,4 @@ This is an anchor link to invalid anchor in current file [invalidAnchorCurrentFi
 This is an anchor link to an invalid anchor [invalidAnchorLink](../linkTestFile.md#header-7)
 This is an anchor link to an invalid anchor in file that needs to resolved as markdown [invalidAnchorLink](../linkTestFile.html#header-7)
 This is an anchor link to a file that does not exist [invalidAnchorLink](invalidLink.md#does-not-exist) 
+ > If these property values do not exist in the settings.xml, the source code might not be following the guidelines at [Setup Guide](../setup-introduction.md)

--- a/test/fixtures/testFiles/validLinkTest.md
+++ b/test/fixtures/testFiles/validLinkTest.md
@@ -15,5 +15,6 @@ This is a link to valid anchor [validAnchorLink](../linkTestFile.md#header-6)
 This is a link to valid anchor in same file [validSameFileAnchor](#valid-links)
 This is a link to valid anchor in same file [validSameFileAnchor](#no-paragraph)
 This is a linkt to valid anchor in file to be resolved as markdown [validMDAnchorLink](../linkTestFile.html#header-5)
+ >This is valid link in the textlint repo [textlint](https://textlint.github.io)
 
 ## No Paragraph

--- a/test/no-dead-relative-link-test.js
+++ b/test/no-dead-relative-link-test.js
@@ -50,6 +50,11 @@ tester.run("no-dead-relative-links", validateRelativeLinks, {
                     message: "invalidLink.md does not exist",
                     line: 7,
                     column: 74
+                },
+                {
+                    message:"setup-introduction.md does not exist",
+                    line: 8,
+                    column: 134
                 }
             ],
             options: {


### PR DESCRIPTION
Description:
removing `Syntax.BlockQuote` from `no-dead-relative-link.js` L18
Tested with blockQuote and dead link and it passed.