### PR TITLE
Fix problem with running this rule in Windows platform

### DIFF
--- a/src/no-dead-relative-link.js
+++ b/src/no-dead-relative-link.js
@@ -1,6 +1,7 @@
 import "@babel/polyfill";
 import fs from 'fs';
-import path from 'path'
+import path from 'path';
+import url from 'url';
 import {parse, Syntax} from '@textlint/markdown-to-ast';
 import {traverse, VisitorOption} from '@textlint/ast-traverse';
 import GithubSlugger from 'github-slugger';
@@ -41,15 +42,18 @@ async function validateRelativeLink(linkNode, context, options) {
     let linkAbsoutePath = path.resolve(path.dirname(context.getFilePath()), linkNode.url);
     let linkURL = new URL("file://" + linkAbsoutePath);
     let linkedFileExtension = path.extname(linkURL.pathname);
+
+
     if (linkedFileExtension !== ".md" && options["resolve-as-markdown"] && options["resolve-as-markdown"].includes(linkedFileExtension)) {
         linkURL.pathname = linkURL.pathname.replace(linkedFileExtension, ".md");
     }
-    if (!await fileExists(linkURL.pathname)) {
+
+    if (!await fileExists(url.fileURLToPath(linkURL))) {
         reportError(linkNode, context, `${path.basename(linkURL.pathname)} does not exist`);
         return;
     } 
     if(linkURL.hash && path.extname(linkURL.pathname) === ".md") {
-        return validateAnchorLink(linkURL.pathname, linkURL.hash.slice(1), linkNode, context);
+        return validateAnchorLink(url.fileURLToPath(linkURL), linkURL.hash.slice(1), linkNode, context);
     }
 }
 


### PR DESCRIPTION
This textlint rule was falsely reporting all relative links as dead/broken when it's executed in Windows platform.

The fix was to properly convert the target URL into a file path. Details and examples can be found here in the documentation:

https://nodejs.org/api/url.html#url_url_pathname

Looking at the documentation, this rule would have failed in non-windows platform too depending on the file name.

Tested the changes by running the unit tests in both Windows and a Mac device. Also tested it by manually copying the build output into another repository where this rule was being used for relative link validation.

closes issue #6 